### PR TITLE
arduino: fix delay() and delayMicroseconds()

### DIFF
--- a/arduino/core/wiring.cpp
+++ b/arduino/core/wiring.cpp
@@ -15,7 +15,7 @@
  License along with this library; if not, write to the Free Software
  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
- Modified: Georgi Angelov 
+ Modified: Georgi Angelov
  */
 
 #include "Arduino.h"
@@ -23,8 +23,8 @@
 void delayMicroseconds(unsigned int us)
 {
 	struct timespec st;
-	st.tv_sec = 0;
-	st.tv_nsec = us * 1000000;
+	st.tv_sec = us / 1000000;
+	st.tv_nsec = us % 1000000 * 1000;
 	nanosleep(&st, NULL);
 }
 
@@ -32,7 +32,7 @@ void delay(unsigned int ms)
 {
 	struct timespec st;
 	st.tv_sec = ms / 1000;
-	st.tv_nsec = ms * 1000000;
+	st.tv_nsec = ms % 1000 * 1000000;
 	nanosleep(&st, NULL);
 }
 
@@ -70,7 +70,7 @@ boolean noStopInterrupts(void)
 uint32_t clockCyclesPerMicrosecond(void)
 {
 	// TODO
-	return 500; 
+	return 500;
 }
 
 uint32_t clockCyclesToMicroseconds(uint32_t a)


### PR DESCRIPTION
In nanosleep(2), the value of timespec.tv_nsec field must be in
the range 0 to 999999999.
Also, one microsecond should equal 1000 nanoseconds, not 1000000.